### PR TITLE
Add Club News section to homepage

### DIFF
--- a/src/components/club-news/index.tsx
+++ b/src/components/club-news/index.tsx
@@ -1,0 +1,38 @@
+import { FunctionalComponent, h } from 'preact';
+import { Post, getActivePosts, formatDate } from '../../lib/posts';
+import postsData from '../../data/posts.json';
+import style from './style.scss';
+
+const posts = getActivePosts(postsData as Post[]);
+
+const ClubNews: FunctionalComponent = () => {
+    return (
+        <section>
+            <h2>Club News</h2>
+            {posts.length === 0 ? (
+                <p class={style.empty}>Check back soon for the latest club news and Support 7 callouts.</p>
+            ) : (
+                <div class={style.grid}>
+                    {posts.map((post) => (
+                        <article key={post.id} class={style.card}>
+                            {post.category && <span class={style.badge}>{post.category}</span>}
+                            <h3>{post.title}</h3>
+                            {post.location && (
+                                <p class={style.location}>
+                                    <i class="fas fa-map-marker-alt" aria-hidden="true" /> {post.location}
+                                </p>
+                            )}
+                            <time class={style.date} dateTime={post.date}>{formatDate(post.date)}</time>
+                            <p>{post.body}</p>
+                            {post.link && (
+                                <p class={style.cardLink}><a href={post.link}>Related link</a></p>
+                            )}
+                        </article>
+                    ))}
+                </div>
+            )}
+        </section>
+    );
+};
+
+export default ClubNews;

--- a/src/components/club-news/style.scss
+++ b/src/components/club-news/style.scss
@@ -1,0 +1,104 @@
+.grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 18px;
+}
+
+.card {
+	position: relative;
+	background: #fff;
+	border: 1px solid #ececec;
+	border-radius: 10px;
+	padding: 22px 24px;
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+	transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+	h3 {
+		margin: 10px 0 4px;
+		font-size: 19px;
+		font-weight: 600;
+		color: #1f1f1f;
+	}
+
+	p {
+		margin: 10px 0 0;
+		line-height: 1.55;
+	}
+}
+
+.card:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
+}
+
+.badge {
+	display: inline-block;
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 0.8px;
+	color: #b22222;
+	background: rgba(178, 34, 34, 0.1);
+	padding: 3px 10px;
+	border-radius: 999px;
+}
+
+.location {
+	margin: 6px 0 0;
+	font-size: 14px;
+	font-weight: 500;
+	color: #b22222;
+
+	i {
+		margin-right: 6px;
+		font-size: 13px;
+	}
+}
+
+.date {
+	display: block;
+	font-size: 13px;
+	color: #888;
+	font-style: italic;
+}
+
+.cardLink {
+	font-size: 14px;
+}
+
+.empty {
+	color: #888;
+	font-style: italic;
+}
+
+@media (min-width: 768px) {
+	.grid {
+		grid-template-columns: 1fr 1fr;
+		gap: 22px;
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	.card {
+		background: #1c1c1c;
+		border-color: #2c2c2c;
+		box-shadow: none;
+
+		h3 {
+			color: #f0f0f0;
+		}
+	}
+
+	.badge {
+		color: #ff8a8a;
+		background: rgba(255, 138, 138, 0.12);
+	}
+
+	.location {
+		color: #ff8a8a;
+	}
+
+	.date {
+		color: #999;
+	}
+}

--- a/src/data/posts.json
+++ b/src/data/posts.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "tps-funeral-2026-06-24",
+    "title": "Deploying for Toronto Police Funeral",
+    "date": "2026-06-20",
+    "category": "Support 7",
+    "body": "Support 7 will be deployed on June 24th in support of the regimental funeral for Toronto Police Constable Marc Pinizzotto. GTMAA members will provide canteen and rehab services to first responders attending the service."
+  },
+  {
+    "id": "club-bbq-2026-06",
+    "title": "Annual Club BBQ",
+    "date": "2026-06-16",
+    "category": "Club News",
+    "body": "Members gathered for the GTMAA's annual summer barbecue. Thanks to everyone who came out and to Peter Garnett for hosting. A great chance to catch up between callouts."
+  },
+  {
+    "id": "sup7-2026-05-31",
+    "title": "2nd Alarm House Fire",
+    "date": "2026-05-31",
+    "category": "Support 7",
+    "location": "130 Ellesmere Road, Scarborough",
+    "body": "Support 7 responded to a 2nd alarm house fire at 130 Ellesmere Road in Maryvale. Eight members provided refreshments on a hot afternoon, logging 22 hours of service before clearing at 1705."
+  },
+  {
+    "id": "sup7-2026-05-29",
+    "title": "2nd Alarm House Fire",
+    "date": "2026-05-29",
+    "category": "Support 7",
+    "location": "38 Madras Crescent, Scarborough",
+    "body": "Support 7 was called out to a 2nd alarm house fire at 38 Madras Crescent in Morningside. Eight members attended and logged 25.5 hours of service. The canteen returned to quarters at 1945."
+  },
+  {
+    "id": "sup7-2026-05-21",
+    "title": "2nd Alarm Dwelling Fire",
+    "date": "2026-05-21",
+    "category": "Support 7",
+    "location": "24 Brigadoon Crescent, Scarborough",
+    "body": "Support 7 responded to a 2nd alarm dwelling fire at 24 Brigadoon Crescent in the L'Amoreaux neighbourhood. Eight members were in attendance from 1840 to 2130, combining for 22 hours of service."
+  },
+  {
+    "id": "sup7-2026-05-04",
+    "title": "3rd Alarm High-Rise Fire",
+    "date": "2026-05-04",
+    "category": "Support 7",
+    "location": "11 Thorncliffe Park Drive, East York",
+    "body": "Support 7 was dispatched to a 3rd alarm high-rise fire at 11 Thorncliffe Park Drive, the same building that saw a prolonged 5-alarm incident last November. Service was provided until 1645, with 18.75 hours of manpower logged."
+  },
+  {
+    "id": "beaches-easter-parade-2026-04-05",
+    "title": "Beaches Easter Parade",
+    "date": "2026-04-05",
+    "category": "Club News",
+    "body": "GTMAA members took part in the annual Beaches Easter Parade along Queen Street East, from Neville Park to Woodbine. A small but dedicated crew represented the club and got the job done."
+  },
+  {
+    "id": "st-patricks-parade-2026-03-15",
+    "title": "St. Patrick's Day Parade",
+    "date": "2026-03-15",
+    "category": "Club News",
+    "body": "GTMAA members joined the annual St. Patrick's Day Parade in downtown Toronto, with Support 7 in service for the day."
+  }
+]

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,38 @@
+export interface Post {
+    id: string;
+    title: string;
+    date: string;
+    body: string;
+    category?: string;
+    location?: string;
+    link?: string;
+}
+
+const STALE_AFTER_MONTHS = 6;
+
+export function formatDate(date: string): string {
+    const d = new Date(date);
+    if (isNaN(d.getTime())) return date;
+    return d.toLocaleDateString('en-CA', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'UTC',
+    });
+}
+
+/**
+ * Returns posts no older than STALE_AFTER_MONTHS, newest first.
+ * Posts with an unparseable date are dropped.
+ */
+export function getActivePosts(posts: Post[], now: Date = new Date()): Post[] {
+    const cutoff = new Date(now);
+    cutoff.setMonth(cutoff.getMonth() - STALE_AFTER_MONTHS);
+
+    return posts
+        .filter((post) => {
+            const d = new Date(post.date);
+            return !isNaN(d.getTime()) && d >= cutoff;
+        })
+        .sort((a, b) => b.date.localeCompare(a.date));
+}

--- a/src/routes/home/index.tsx
+++ b/src/routes/home/index.tsx
@@ -1,28 +1,37 @@
 import { FunctionalComponent, h } from 'preact';
-import cx from '../../lib/cx';
+import { Helmet } from 'react-helmet';
+import ClubNews from '../../components/club-news';
 import style from './style.scss';
 
 const Home: FunctionalComponent = () => {
-    return <div class={style.home}>
-        <section class={cx(style.section, style.group)}>
-            <div class={cx(style.col, style.span_1_of_2)}>
-                <h1>WELCOME</h1>
-                <p>The members of the Greater Toronto Multiple Alarm Association welcome you to our voice on the internet. We are one of the largest fire buff clubs in Canada, providing canteen and rehab services to the Toronto Fire Services (and previous fire departments) for almost 40 years. Fires happen day and night, often in the worst weather possible. Our volunteers are prepared to answer the call whenever it comes.</p>
-                <p>The G.T.M.A.A. is an inclusive, non-profit organization that is always looking for new fire buffs and fire service enthusiasts to fill out our ranks. Persons of all ages, including those belonging to other public service organizations, are always welcome. Check out our event calendar and get in touch if you are interested in joining us.</p>
-            </div>
-            <img class={cx(style.col, style.span_1_of_2)} src="assets/people/2013-fallen-firefighter-memorial_thumb.jpg" />
-        </section>
+    return (
+        <div class={style.home}>
+            <Helmet>
+                <title>Greater Toronto Multiple Alarm Association</title>
+            </Helmet>
 
-        <section>
-            <h2>Meetings</h2>
-            <p>A general business meeting is held on the third Tuesday of every month, starting at 7 P.M. Each meeting is open to guests with the exception of the April meeting. Most meetings conclude with some type of entertainment - either slides or a video or a guest speaker. Some months we hold our meetings off site at another fire service facility. Guests are advised to contact us before visiting to confirm the location.</p>
-        </section>
+            <section class={style.welcome}>
+                <div class={style.welcomeText}>
+                    <h2>Welcome</h2>
+                    <p>The members of the Greater Toronto Multiple Alarm Association welcome you to our voice on the internet. We are one of the largest fire buff clubs in Canada, providing canteen and rehab services to the Toronto Fire Services (and previous fire departments) for almost 40 years. Fires happen day and night, often in the worst weather possible. Our volunteers are prepared to answer the call whenever it comes.</p>
+                    <p>The G.T.M.A.A. is an inclusive, non-profit organization that is always looking for new fire buffs and fire service enthusiasts to fill out our ranks. Persons of all ages, including those belonging to other public service organizations, are always welcome. Check out our event calendar and get in touch if you are interested in joining us.</p>
+                </div>
+                <img class={style.welcomeImg} src="/assets/people/2013-fallen-firefighter-memorial_thumb.jpg" alt="GTMAA members at the 2013 Fallen Firefighter Memorial" />
+            </section>
 
-        <section>
-            <h2>The Trumpet</h2>
-            <p>The Trumpet is the voice of the Greater Toronto Multiple Alarm Association. Since 1976 it has been the foremost source on fire service information in the Toronto area. No other publication gives you more - apparatus deliveries, department news, a monthly synopsis of major multiple alarm incidents, as well as the latest club news. Most issues are rounded out with interesting photos. For the low price of $10, receive a PDF version of The Trumpet in your inbox every month of the year. Contact us today to sign up for your subscription.</p>
-        </section>
-    </div>;
+            <ClubNews />
+
+            <section>
+                <h2>Meetings</h2>
+                <p>A general business meeting is held on the third Tuesday of every month, starting at 7 P.M. Each meeting is open to guests with the exception of the April meeting. Most meetings conclude with some type of entertainment - either slides or a video or a guest speaker. Some months we hold our meetings off site at another fire service facility. Guests are advised to contact us before visiting to confirm the location.</p>
+            </section>
+
+            <section>
+                <h2>The Trumpet</h2>
+                <p>The Trumpet is the voice of the Greater Toronto Multiple Alarm Association. Since 1976 it has been the foremost source on fire service information in the Toronto area. No other publication gives you more - apparatus deliveries, department news, a monthly synopsis of major multiple alarm incidents, as well as the latest club news. Most issues are rounded out with interesting photos. For the low price of $10, receive a PDF version of The Trumpet in your inbox every month of the year. Contact us today to sign up for your subscription.</p>
+            </section>
+        </div>
+    );
 };
 
 export default Home;

--- a/src/routes/home/style.scss
+++ b/src/routes/home/style.scss
@@ -1,18 +1,57 @@
 @use '~style/grid';
 
 .home {
-	padding: 56px 20px;
+	padding: 56px 20px 40px;
 	min-height: 100%;
 	width: 100%;
 
-	section:not(:first-of-type):not(:last-of-type) {
+	section:not(.hero):not(:last-of-type) {
 		border-bottom: 1px solid lightgray;
-		padding: 50px 0;
+		padding: 44px 0;
 	}
+
+	h2 {
+		font-size: 28px;
+		font-weight: 600;
+		margin: 0 0 20px;
+		letter-spacing: 0.2px;
+	}
+}
+
+/* Welcome */
+.welcome {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 28px;
+	align-items: center;
+}
+
+.welcomeImg {
+	width: 100%;
+	border-radius: 8px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+	object-fit: cover;
 }
 
 @media (min-width: 768px) {
 	.home {
-		padding: 56px 100px;
+		padding: 56px 100px 60px;
+	}
+
+	.welcome {
+		grid-template-columns: 1fr 1fr;
+		gap: 40px;
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	.home {
+		h2 {
+			color: #f0f0f0;
+		}
+
+		section:not(.hero):not(:last-of-type) {
+			border-bottom-color: #2a2a2a;
+		}
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
 
         /* Module Resolution Options */
         "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "resolveJsonModule": true,                /* Allow importing .json files as modules. */
         "esModuleInterop": true,                  /* */
         // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */


### PR DESCRIPTION
## Purpose

Add a Club News section to the homepage that shows recent club activity and Support 7 callouts. Entries come from a build-time dataset, are hidden once older than 6 months, and render in their own component.